### PR TITLE
Fix can not create BrowserWindow before app is ready

### DIFF
--- a/__tests__/AppTest.js
+++ b/__tests__/AppTest.js
@@ -32,7 +32,7 @@ test("Test app name and version", async () => {
   const appVersion = await electronApp.evaluate(async ({ app }) => {
     return  app.getVersion();
   });
-  expect(appVersion).toBe("0.1.4");
+  expect(appVersion).toBe("0.1.5");
   expect(appName).toBe("panta");
 });
 

--- a/main.js
+++ b/main.js
@@ -62,7 +62,7 @@ app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (BrowserWindow.getAllWindows().length === 0) {
-    win = createWindow()
+    app.whenReady().then(createWindow)
   } else {
     win.show()
     win.restore()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panta",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panta",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "description": "simple clipboard utility program",
   "homepage": "https://github.com/muzir/panta",


### PR DESCRIPTION
Fix can not create BrowserWindow before app is ready which is an issue for Mac.

https://github.com/muzir/panta/issues/33